### PR TITLE
PC-2690: Fix page doesn't start at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,17 @@ The parent window contains this JS code for listening to postMessages {object} s
 <!-- Files from this repo -->
 <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/PostCo/embed-iframe/iframe-listener.min.js"></script>
 ```
-### 
+
+### How to push a new version to jsdelivr
+- Make change(s) to the code, push it to the remote repo as usually.
+- Once the new code is merged into the `main` branch, draft a new release.
+  - Visit the repo on GitHub, go to Releases section (it sits between the About section and Packages section).
+  - Click "Draft a new release".
+  - Fill in the fields:
+    - Tag: create a new, incremented tag. For example, the latest release is `v1.0.4`, then the tag should be `v1.0.5`.
+    - Target: the main branch.
+    - Relase title: same as Tag.
+    - Description: self-explanatory.
+  - Check the "Set as the latest release".
+  - Click on "Draft a new release".
+- Once everything is reviewed and tested carefully, go to the Releases section, click on Edit icon of the draft release and click "Publish release".

--- a/iframe-listener.js
+++ b/iframe-listener.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", function () {
   console.log("Initial height > ", initialHeight);
 
   window.onmessage = (event) => {
-    if (event.origin.match(/360\.postco\.co/)) {
+    if (event.origin.match(/postco\.co/)) {
       console.log("Parent received---", event.data);
 
       let { type, height, isRoot, resetHeight } = event.data;
@@ -31,7 +31,8 @@ document.addEventListener("DOMContentLoaded", function () {
           iframe.style.height = height + "px";
         }
       } else if (type === "scrollToTop") {
-        iframe.scrollIntoView();
+        window.scrollTo(0, 0);
+        iframe.scrollTo(0, 0);
       }
     }
   };


### PR DESCRIPTION
# What is done in this PR:

- Update the origin check from "360.postco.co" to "postco.co"
- on "scrollToTop" event, use `scrollTo(0, 0)` instead of `scrollIntoView`. This is because sometimes, the `scrollIntoView` doesn't scroll the page all the way to the top, [as noted here by MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#notes).
# Note

The original plan was to add a note that the URL has to include "360.postco.co" for the embedded app to work properly. But I think that removing the "360" check (URL has to include only "postco.co") is a better solution, because:

- We removed "360" from our app name, now it's only "PostCo".
- As "360.postco.co" includes "postco.co", we keep the backward compatibility.

# Showcase video

https://drive.google.com/file/d/1lJxSSkfpVBfoRp7cp3KpxZt2DT8o2Kbp/view?usp=drive_link